### PR TITLE
[최윤혁] LinkedList 적용 HashMap 구현2

### DIFF
--- a/src/main/java/study/flab/learn/cyh/DataStructure/CustomHashMapUsingLinkedList2.java
+++ b/src/main/java/study/flab/learn/cyh/DataStructure/CustomHashMapUsingLinkedList2.java
@@ -1,0 +1,177 @@
+package study.flab.learn.cyh.DataStructure;
+
+import java.io.Serializable;
+import java.util.*;
+
+public class CustomHashMapUsingLinkedList2<K, V> implements Serializable {
+
+    private static final int INITIAL_CAPACITY = 16;
+    private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+    public int capacity;
+    public float loadFactor;
+    public LinkedList<CustomEntryToCHMUL2<K, V>>[] table;
+    public int tableSize;
+
+    public CustomHashMapUsingLinkedList2() {
+        this(INITIAL_CAPACITY, DEFAULT_LOAD_FACTOR);
+    }
+    public CustomHashMapUsingLinkedList2(int capacity) {
+        this(capacity, DEFAULT_LOAD_FACTOR);
+    }
+    public CustomHashMapUsingLinkedList2(float loadFactor) {
+        this(INITIAL_CAPACITY, loadFactor);
+    }
+    public CustomHashMapUsingLinkedList2(int capacity, float loadFactor) {
+        if (loadFactor <= 0 || Float.isNaN(loadFactor))
+            throw new IllegalArgumentException("Illegal load factor: " + loadFactor);
+        this.loadFactor = loadFactor;
+        this.capacity = capacity;
+        this.table = new LinkedList[this.capacity];
+    }
+
+    //O(n)
+    public V get(K key) {
+        int tableIndex = key.hashCode() % this.capacity;
+
+        if (this.table[tableIndex] == null) {
+            return null;
+        }
+
+        CustomEntryToCHMUL2<K,V> entry = this.table[tableIndex].getFirst();
+        while (entry != null) {
+            if (entry.key.equals(key)) {
+                return entry.value;
+            }
+            entry = entry.nextEntry;
+        }
+        return null;
+    }
+
+    //O(n)
+    private LinkedList<CustomEntryToCHMUL2<K, V>>[] incCapacitySize() {
+        int prevCapacity = this.capacity;
+        this.capacity *= 2;
+        LinkedList<CustomEntryToCHMUL2<K, V>>[] newTable = new LinkedList[this.capacity];
+        for (int i = 0; i < prevCapacity; i++) {
+            if (this.table[i] != null) {
+                newTable[i] = this.table[i];
+            }
+        }
+        return newTable;
+    }
+
+    //O(n)
+    public void put(K key, V value) {
+        if (loadFactor * this.capacity <= this.tableSize) {
+            this.table = incCapacitySize();
+        }
+
+        CustomEntryToCHMUL2<K, V> newEntry = new CustomEntryToCHMUL2<>(key, value);
+
+        int tableIndex = key.hashCode() % this.capacity;
+        LinkedList<CustomEntryToCHMUL2<K, V>> bucket = this.table[tableIndex];
+        if (bucket == null) {
+            this.table[tableIndex] = new LinkedList<>();
+            this.table[tableIndex].add(newEntry);
+            tableSize++;
+            return;
+        }
+
+        CustomEntryToCHMUL2<K, V> entry = this.table[tableIndex].getFirst();
+        while (entry.nextEntry != null) {
+            //중복KEY 처리
+            if (entry.key.equals(key)) {
+                entry.value = value;
+                return;
+            }
+            entry = entry.nextEntry;
+        }
+
+        //중복KEY 처리
+        if (entry.key.equals(key)) {
+            entry.value = value;
+            return;
+        }
+        entry.nextEntry = newEntry;
+        tableSize++;
+    }
+
+    //O(1)
+    public int getEmptyEntry() {
+        return this.capacity - this.tableSize;
+    }
+    //O(1)
+    public int size() {
+        return tableSize;
+    }
+    //O(1)
+    public boolean isEmpty() {
+        return tableSize == 0;
+    }
+    //O(n)
+    public Set<Map.Entry<K, V>> entrySet() {
+        Set<Map.Entry<K, V>> set = new HashSet<>();
+        for (int i = 0; i < this.capacity; i++) {
+            if (this.table[i] != null) {
+                for (int j = 0; j < this.table[i].size(); j++) {
+                    set.add(this.table[i].get(j));
+                }
+            }
+        }
+        return set;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomHashMapUsingLinkedList2{" +
+                "\ncapacity=" + capacity +
+                "\n, loadFactor=" + loadFactor +
+                "\n, table=" + Arrays.toString(table) +
+                "\n, tableSize=" + tableSize +
+                "\n}";
+    }
+}
+
+class CustomEntryToCHMUL2<K, V> implements Map.Entry<K, V> {
+
+    final K key;
+    V value;
+    CustomEntryToCHMUL2<K,V> nextEntry;
+    CustomEntryToCHMUL2<K,V> prevEntry;
+
+    public CustomEntryToCHMUL2() {
+        this.key = null;
+        this.value = null;
+        this.nextEntry = null;
+        this.prevEntry = null;
+    }
+
+    CustomEntryToCHMUL2(K key, V value) {
+        this.key = key;
+        this.value = value;
+        this.nextEntry = null;
+        this.prevEntry = null;
+    }
+
+    @Override
+    public K getKey() {
+        return this.key;
+    }
+
+    @Override
+    public V getValue() {
+        return this.value;
+    }
+
+    @Override
+    public V setValue(V value) {
+        V prevValue = this.value;
+        this.value = value;
+        return prevValue;
+    }
+
+    @Override
+    public String toString() {
+        return key + "=" + value;
+    }
+}

--- a/src/test/java/study/flab/learn/cyh/DataStructure/CustomHashMapUsingLinkedList2Test.java
+++ b/src/test/java/study/flab/learn/cyh/DataStructure/CustomHashMapUsingLinkedList2Test.java
@@ -1,0 +1,210 @@
+package study.flab.learn.cyh.DataStructure;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CustomHashMapUsingLinkedList2Test {
+
+    private CustomHashMapUsingLinkedList2 cMap = new CustomHashMapUsingLinkedList2();
+    private Map jMap;
+
+    @BeforeEach
+    void setUp() {
+        cMap = new CustomHashMapUsingLinkedList2();
+        jMap = new HashMap();
+    }
+
+    @Test
+    void when_매개변수_capacity로_CustomHashMap의_생성자를_선언한다_Expect_멤버변수_loadFactor와_buckets의_크기가_초기화된다() {
+        //given
+        float default_cMap_loadFactor = 0.75f;
+        int default_cMap_capacity = 16;
+        int default_cMap_tableSize = 0;
+        assertThat(cMap.loadFactor).isEqualTo(default_cMap_loadFactor);
+        assertThat(cMap.capacity).isEqualTo(default_cMap_capacity);
+        assertThat(cMap.tableSize).isEqualTo(default_cMap_tableSize);
+
+        //when
+        cMap = new CustomHashMapUsingLinkedList2(20);
+
+        //then
+        assertThat(cMap.table.length).isEqualTo(20);
+    }
+
+    @Test
+    void when_매개변수_loadFactor로_CustomHashMap의_생성자를_선언한다_Expect_멤버변수_loadFactor와_buckets의_크기가_초기화된다() {
+        //given
+        float default_cMap_loadFactor = 0.75f;
+        int default_cMap_capacity = 16;
+        int default_cMap_tableSize = 0;
+        assertThat(cMap.loadFactor).isEqualTo(default_cMap_loadFactor);
+        assertThat(cMap.capacity).isEqualTo(default_cMap_capacity);
+        assertThat(cMap.tableSize).isEqualTo(default_cMap_tableSize);
+
+        //when
+        cMap = new CustomHashMapUsingLinkedList2(0.85f);
+
+        //then
+        assertThat(cMap.loadFactor).isEqualTo(0.85f);
+    }
+
+    @Test
+    void when_put_메서드를_사용하여_값을_넣는다_Expect_정상처리() {
+        //given
+        float default_cMap_loadFactor = 0.75f;
+        int default_cMap_capacity = 16;
+        int key = 1;
+        String value = "1번";
+
+        //when
+        cMap.put(key, value);
+
+        //then
+        assertThat(cMap.loadFactor).isEqualTo(default_cMap_loadFactor);
+        assertThat(cMap.capacity).isEqualTo(default_cMap_capacity);
+        assertThat(cMap.tableSize).isEqualTo(1);
+    }
+
+    @Test
+    void when_get_메서드를_사용하여_값을_가져온다_Expect_정상처리() {
+        //given
+        int key1 = 1, key2 = 2;
+        String value1 = "1번", value2 = "2번";
+
+        //when
+        cMap.put(key1, value1);
+        cMap.get(key1);
+        cMap.put(key2, value2);
+        jMap.put(key1, value1);
+        jMap.put(key2, value2);
+
+        //then
+        assertThat(cMap.get(key1)).isEqualTo(value1);
+        assertThat(cMap.get(key2)).isEqualTo(value2);
+        assertThat(jMap.get(key1)).isEqualTo(value1);
+        assertThat(jMap.get(key2)).isEqualTo(value2);
+    }
+
+    @Test
+    void when_put_메서드를_사용하여_동일한_key값으로_넣은후_value를_가져온다_Expect_마지막에_넣은_value가_리턴() {
+        //given
+        int uniqueKey = 1;
+        String value1 = "1번", value2 = "2번";
+
+        //when
+        cMap.put(uniqueKey, value1);
+        cMap.put(uniqueKey, value2);
+        jMap.put(uniqueKey, value1);
+        jMap.put(uniqueKey, value2);
+
+        //then
+        assertThat(cMap.get(uniqueKey)).isEqualTo(value2);
+        assertThat(jMap.get(uniqueKey)).isEqualTo(value2);
+    }
+
+    @Test
+    void when_put_메서드를_사용하여_max_capacity를_초과하는_값을_넣는다_Expect_HashMap의_tableSize가_2배로_재정의되며_정상출력() {
+        //given
+        assertThat(cMap.isEmpty()).isTrue();
+        int count = 16;
+        int key = 17;
+        String value = "17번";
+
+        //when
+        for (int i = 1; i <= count; i++) {
+            cMap.put(i, i+"번");
+        }
+        cMap.put(key, value);
+
+        //then
+        assertThat(cMap.get(key)).isEqualTo(value);
+        assertThat(cMap.size()).isEqualTo(17);
+    }
+
+    @Test
+    void when_HashMap이_비어있지_않을_경우_남은_entry를_확인하기위해_getEmptyEntry메소드를_호출_Expect_몇개의_entry가_비어있는지_확인가능() {
+        //given
+        int count = 16;
+
+        //when
+        for (int i = 1; i <= count; i++) {
+            cMap.put(i, i+"번");
+        }
+        int emptyEntry = cMap.capacity - count;
+
+        //then
+        assertThat(cMap.getEmptyEntry()).isEqualTo(emptyEntry);
+    }
+
+    @Test
+    void when_HashTable에_넣지않은_값을_get함수를_통해_확인_Expect_리턴값으로_null_확인() {
+        //given
+        int key1 = 1, key2 = 2;
+        String value1 = "1번";
+
+        //when
+        cMap.put(key1, value1);
+        jMap.put(key1, value1);
+
+        //then
+        assertThat(cMap.get(key2)).isEqualTo(null);
+        assertThat(jMap.get(key2)).isEqualTo(null);
+    }
+
+    @Test
+    void when_put_메서드를_사용하여_bucket에_2개_이상의_entry를_넣는다_Expect_bucket_내부에서_서로다른_key값으로_각각의_value를_확인가능() {
+        //given
+        assertThat(cMap.isEmpty()).isTrue();
+        int count = 16;
+        int resultCount = 18;
+        int key1 = 32;
+        int key2 = 33;
+        String value1 = "32번";
+        String value2 = "33번";
+
+        //when
+        for (int i = 1; i <= count; i++) {
+            cMap.put(i, i+"번");
+        }
+        System.out.println(cMap.toString());
+        cMap.put(key1, value1);
+        System.out.println(cMap.toString());
+        cMap.put(key2, value2);
+        System.out.println(cMap.toString());
+
+        //then
+        assertThat(cMap.size()).isEqualTo(resultCount);
+        assertThat(cMap.get(key1)).isEqualTo(value1);
+        assertThat(cMap.get(key2)).isEqualTo(value2);
+    }
+
+    @Test
+    void when_entrySet을_호출한다_Expect_HashMap에_저장된_모든_entry를_확인가능() {
+        //given
+        int count = 16;
+
+        //when
+        for (int i = 1; i <= count; i++) {
+            cMap.put(i, i+"번");
+        }
+        for (int i = 1; i <= count; i++) {
+            jMap.put(i, i+"번");
+        }
+
+        //then
+        assertThat(cMap.entrySet().size()).isEqualTo(count);
+        assertThat(jMap.entrySet().size()).isEqualTo(count);
+    }
+
+
+//    @Test
+//    void when_테스트상태_Expect_기대결과() {
+//
+//    }
+}


### PR DESCRIPTION
## 개요
CustomHashMapUsingLinkedList2 클래스 신규작성

## 작업사항
- HashMap 직접구현
- Separate Chaining을 적용하여 하나의 bucket에서 서로다른 key를 가지는 Entry를 다수 저장 가능하도록 구현
	- Map.Entry를 구현하여 key-value 한 쌍을 가지는 CustomEntryToCHMUL2 클래스 생성
- 상기 CustomEntryToCHMUL2 클래스를 타입으로 가진 콜렉션을 인스턴스 변수로 가진 CustomHashMapUsingLinkedList2 클래스 구현
    - LinkedList< CustomEntryToCHMUL2>[]
- loadFactor를 이용하여 LinkedList[] 콜렉션의 capacity를 확장시키는 임계점 지정
	- incCapacitySize()